### PR TITLE
Figure XY: Backgroundmaps

### DIFF
--- a/backgroundmaps_grdimage_contextily.ipynb
+++ b/backgroundmaps_grdimage_contextily.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ce47316-ac7b-480b-9a82-6c9e0f989adf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import contextily\n",
+    "import pygmt\n",
+    "\n",
+    "\n",
+    "fig = pygmt.Figure()\n",
+    "\n",
+    "fig.basemap(region=\"IS\", projection=\"M12c\", frame=\"af\")\n",
+    "# Download 3 arc-minutes global relief using the country code for Iceland (\"IS\")\n",
+    "grid = pygmt.datasets.load_earth_relief(resolution=\"03m\", region=\"IS\")\n",
+    "fig.grdimage(grid=grid, cmap=\"SCM/oleron\")\n",
+    "fig.colorbar(frame=[\"x+lElevation\", \"y+lm\"], position=\"JTC+h\")\n",
+    "fig.plot(x=-21.92, y=64.12, style=\"s1c\", pen=\"3p,darkorange\")\n",
+    "\n",
+    "fig.shift_origin(xshift=\"w+1c\")\n",
+    "\n",
+    "fig.tilemap(\n",
+    "    region=[-22.2, -21.6, 64, 64.2],  # Area around Reykjavik\n",
+    "    projection=\"M13.5c\",\n",
+    "    # Set level of details (0-22)\n",
+    "    # Higher levels mean a zoom level closer to the Earth's surface with\n",
+    "    # more tiles covering a smaller geographic area and thus more details\n",
+    "    # and vice versa. Please note, not all zoom levels are always available.\n",
+    "    zoom=10,\n",
+    "    # Use tiles from OpenStreetMap tile server\n",
+    "    source=\"https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png\",\n",
+    "    frame=[\"wSnE\", \"af\"],\n",
+    ")\n",
+    "\n",
+    "fig.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a JN for **backgroundmaps**:

- [ ] Downloade on of the GMT remote datasets and plot it via `Figure.grdimage`
- [ ] Downloade tiled maps using `contextily` and plot it via `Figure.tilemaps`