### PR TITLE
DOC: Add paper title to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # PyGMT paper figures
 
-This repository contains the Jupyter notebooks and supporting data used to generate the figures presented in the PyGMT paper.
+This repository contains the Jupyter notebooks and supporting data used to generate the figures presented in the PyGMT paper:
+
+**Dongdong Tian**, Yvonne Fröhlich, Wei Ji Leong, Michael Grund,
+William Schlitzer, Max Jones, Leonardo Uieda, Joaquim Manuel Freire Luis
+
+> PyGMT: Bridging Python and the Generic Mapping Tools for Geospatial Visualization and Analysis
+
+*Submitted to _Geochemistry, Geophysics, Geosystems_*
 
 ## Files
 
 - [`Fig1_PyGMT_GMT_comparison.ipynb`](Fig1_PyGMT_GMT_comparison.ipynb): Example comparison of GMT CLI (Bash) and PyGMT (Python) scripts
 - [`Fig2_PyGMT_ecosystem.ipynb`](Fig2_PyGMT_ecosystem.ipynb): The PyGMT ecosystem
-- [`Fig3_PyGMT_backgrounds.ipynb`](Fig3_PyGMT_backgrounds.ipynb): Different types of geographic background base maps of Iceland
+- [`Fig3_PyGMT_backgrounds.ipynb`](Fig3_PyGMT_backgrounds.ipynb): Different types of geographic background basemaps of Iceland
 - [`Fig4_PyGMT_pandas.ipynb`](Fig4_PyGMT_pandas.ipynb): Seismicity along the Andaman-Sumatra-Java Subduction Zone
 - [`Fig5_PyGMT_xarray.ipynb`](Fig5_PyGMT_xarray.ipynb): Hemispherical views of long-wavelength Mars topography
 - [`Fig6_PyGMT_geopandas.ipynb`](Fig6_PyGMT_geopandas.ipynb): Choropleth map of the population in the US

--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 This repository contains the Jupyter notebooks and supporting data used to generate the figures presented in the PyGMT paper:
 
-**Dongdong Tian**, Yvonne Fröhlich, Wei Ji Leong, Michael Grund,
-William Schlitzer, Max Jones, Leonardo Uieda, Joaquim Manuel Freire Luis
-
+> **Dongdong Tian**, Yvonne Fröhlich, Wei Ji Leong, Michael Grund, William Schlitzer, Max Jones, Leonardo Uieda, Joaquim Manuel Freire Luis
+> 
 > PyGMT: Bridging Python and the Generic Mapping Tools for Geospatial Visualization and Analysis
-
-*Submitted to _Geochemistry, Geophysics, Geosystems_*
+>
+> *Submitted to _Geochemistry, Geophysics, Geosystems_*
 
 ## Files
 


### PR DESCRIPTION
I think "The PyGMT paper" sounds a bit general. As we need to upload already this version to Zenodo and I suggest to add the expecit title all authors of the submitted manuscript to the README.

**Preview**:
https://github.com/GenericMappingTools/pygmt-paper-figures/blob/add-paper-readme/README.md#pygmt-paper-figures