### PR TITLE
Figure3: Set surface type to 'image' in Figure.grdview call

### DIFF
--- a/Fig3_PyGMT_backgrounds.ipynb
+++ b/Fig3_PyGMT_backgrounds.ipynb
@@ -64,7 +64,7 @@
     "    fig.grdview(\n",
     "        grid=grd_relief,\n",
     "        cmap=\"SCM/oleron\",\n",
-    "        surftype=\"surface\",\n",
+    "        surftype=\"image\",\n",
     "        shading=True,\n",
     "        zsize=\"1.5c\",\n",
     "        facade_fill=\"gray\",\n",
@@ -91,7 +91,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.3"
+   "version": "3.14.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Currently, we use `surftype="surface"` in the `Figure.grdview` call. The resulting PDF is approximately 15 MB in size and does not render particularly well in PDF format. If I understand correctly, the `"surface"` style draws the surface using a large number of polygons. While this works well for lower-resolution grids, it becomes inefficient for high-resolution grids because of the large polygon count.

This PR changes the surface type to `"image"` instead, which renders the surface as a raster image. The resulting PNG output is virtually identical, while the PDF output is significantly smaller and visually cleaner.

| `surftype="surface"` (PDF 15 MB)| `surftype="image"` (PDF 1.7 MB) |
|---|---|
|<img width="2704" height="1556" alt="image" src="https://github.com/user-attachments/assets/599ac3dd-ce10-413d-b152-75ed6fd83c33" />| <img width="1340" height="776" alt="image" src="https://github.com/user-attachments/assets/1ee8df1f-992b-4ce1-832d-09b00e8209c0" />|
