### PR TITLE
Figure4: Use log scale for Y-axis of the histogram

### DIFF
--- a/Fig4_PyGMT_pandas.ipynb
+++ b/Fig4_PyGMT_pandas.ipynb
@@ -78,7 +78,7 @@
     "    position=Position(\"BL\", offset=0.2),\n",
     "    width=7,\n",
     "    height=4,\n",
-    "    clearance=(1.3, 0.2, 1.1, 0.2),\n",
+    "    clearance=(1.4, 0.2, 1.1, 0.2),\n",
     "    box=True,\n",
     "):\n",
     "    fig.histogram(\n",

--- a/Fig4_PyGMT_pandas.ipynb
+++ b/Fig4_PyGMT_pandas.ipynb
@@ -83,7 +83,7 @@
     "):\n",
     "    fig.histogram(\n",
     "        region=[4.8, 9.2, 0, 0],\n",
-    "        projection=\"X?/?\",\n",
+    "        projection=\"X?/?l\",\n",
     "        frame=Frame(\n",
     "            axes=\"WSrt\",\n",
     "            xaxis=Axis(annot=1, tick=0.2, label=\"Magnitude\"),\n",
@@ -116,7 +116,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.3"
+   "version": "3.14.5"
   }
  },
  "nbformat": 4,

--- a/Fig4_PyGMT_pandas.ipynb
+++ b/Fig4_PyGMT_pandas.ipynb
@@ -82,7 +82,7 @@
     "    box=True,\n",
     "):\n",
     "    fig.histogram(\n",
-    "        region=[4.8, 9.2, 0, 0],\n",
+    "        region=[4.8, 8.2, 0, 0],\n",
     "        projection=\"X?/?l\",\n",
     "        frame=Frame(\n",
     "            axes=\"WSrt\",\n",


### PR DESCRIPTION
Set the Y-axis to log-scale, following the Gutenberg-Richter law.
| Old | New |
|---|---|
| <img width="1910" height="1978" alt="Fig4_PyGMT_pandas" src="https://github.com/user-attachments/assets/3d6fcc5c-f219-40d2-936b-62cd9a7591ce" /> | <img width="1910" height="1978" alt="Fig4_PyGMT_pandas" src="https://github.com/user-attachments/assets/e932099d-2612-4f2c-a763-1f04f067542c" /> |


