### PR TITLE
README: Fix display of badge and link to file of LICENSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyGMT paper figures
 
-![GitHub License](https://img.shields.io/github/license/GenericMappingTools/pygmt-paper-figures)
+[![GitHub License](https://img.shields.io/github/license/GenericMappingTools/pygmt-paper-figures?style=flat)](https://github.com/GenericMappingTools/pygmt-paper-figures/blob/main/LICENSE)
 [![Digital Object Identifier for the Zenodo archive](https://zenodo.org/badge/DOI/10.5281/zenodo.19412361.svg)](https://doi.org/10.5281/zenodo.19412361)
 
 This repository contains the Jupyter notebooks and supporting data used to generate the figures presented in the PyGMT paper:


### PR DESCRIPTION
Currently the badge for the LICENSE is incorrectly displayed. This PR aims to fix this (xref https://github.com/badges/shields/issues/11496).

| main | this branch |
| ---  | --- |
| <img width="408" height="121" alt="licence_badge" src="https://github.com/user-attachments/assets/13cb348c-9fa9-4517-b240-ec74950f6883" /> | <img width="143" height="134" alt="licence_badge_fixed" src="https://github.com/user-attachments/assets/d71670c6-91ef-4e83-adb1-914ae07c006f" /> |
