### PR TITLE
Figs1&6: Update Figure.text's offset parameter to the new syntax and bump to pygmt v0.19.0dev229

### DIFF
--- a/Fig1_PyGMT_GMT_comparison.ipynb
+++ b/Fig1_PyGMT_GMT_comparison.ipynb
@@ -122,8 +122,8 @@
     "fig.basemap(projection=\"R7c\", region=[0, 360, -90, 90], frame=True)\n",
     "fig.coast(land=\"tan\", water=\"lightblue\")\n",
     "fig.text(position=\"MC\", text=\"PyGMT\", font=\"40p,AvantGarde-Book,red@75\")\n",
-    "fig.text(text=\"(c)\", position=\"TL\", font=\"9p,Helvetica-Bold\", offset=\"-0.5/0.6\", no_clip=True)\n",
-    "       \n",
+    "fig.text(text=\"(c)\", position=\"TL\", font=\"9p,Helvetica-Bold\", offset=(-0.5, 0.6), no_clip=True)\n",
+    "\n",
     "fig.show()\n",
     "fig.savefig(\"Fig1_PyGMT_GMT_comparison.png\")"
    ]
@@ -131,7 +131,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "pygmt",
    "language": "python",
    "name": "python3"
   },
@@ -145,7 +145,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.13.9"
   }
  },
  "nbformat": 4,

--- a/Fig6_PyGMT_geopandas.ipynb
+++ b/Fig6_PyGMT_geopandas.ipynb
@@ -60,7 +60,7 @@
     "    x=cities.geometry.x,\n",
     "    y=cities.geometry.y,\n",
     "    text=cities[\"name\"],\n",
-    "    offset=\"0.35c/0.2c\",\n",
+    "    offset=(0.35, 0.2),\n",
     "    justify=\"BC\",\n",
     "    font=\"4.5p,Helvetica-Bold\",\n",
     "    fill=\"white@30\",\n",
@@ -86,7 +86,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "pygmt",
    "language": "python",
    "name": "python3"
   },
@@ -100,7 +100,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.3"
+   "version": "3.13.9"
   }
  },
  "nbformat": 4,

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ These notebooks require a **development version of PyGMT**. The environment defi
 in `environment.yml` currently installs PyGMT from TestPyPI:
 
 - GMT: `6.6.0`
-- pygmt: `0.19.0.dev219`
+- pygmt: `0.19.0.dev229`
 
 Create and activate the environment:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ These notebooks require a **development version of PyGMT**. The environment defi
 in `environment.yml` currently installs PyGMT from TestPyPI:
 
 - GMT: `6.6.0`
-- pygmt: `0.19.0.dev229`
+- PyGMT: `0.19.0.dev229`
 
 Create and activate the environment:
 

--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,4 @@ dependencies:
   - xarray=2026.4.0
   - pip:
       - --index-url https://test.pypi.org/simple/
-      - pygmt==0.19.0.dev219
+      - pygmt==0.19.0.dev229


### PR DESCRIPTION
After https://github.com/GenericMappingTools/pygmt/pull/4652