### PR TITLE
Figure1: Use four spaces for indentation and bump to pygmt-0.19.0.dev265

### DIFF
--- a/Fig1_PyGMT_GMT_comparison.ipynb
+++ b/Fig1_PyGMT_GMT_comparison.ipynb
@@ -83,9 +83,9 @@
     "# The leading tab characters are intentional to match the indentation.\n",
     "gmt_str = \"\"\"\n",
     "gmt begin GMT_map png\n",
-    "\\tgmt basemap -JR7c -R0/360/-90/90 -B\n",
-    "\\tgmt coast -Gtan -Slightblue\n",
-    "\\techo PyGMT | gmt text -F+f40p,AvantGarde-Book,red@@75+cMC\n",
+    "    gmt basemap -JR7c -R0/360/-90/90 -B\n",
+    "    gmt coast -Gtan -Slightblue\n",
+    "    echo PyGMT | gmt text -F+f40p,AvantGarde-Book,red@@75+cMC\n",
     "gmt end show\n",
     "\"\"\".splitlines()"
    ]
@@ -131,7 +131,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pygmt",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -145,7 +145,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.9"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ These notebooks require a **development version of PyGMT**. The environment defi
 in `environment.yml` currently installs PyGMT from TestPyPI:
 
 - GMT: `6.6.0`
-- PyGMT: `0.19.0.dev229`
+- PyGMT: `0.19.0.dev265`
 
 Create and activate the environment:
 

--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,4 @@ dependencies:
   - xarray=2026.4.0
   - pip:
       - --index-url https://test.pypi.org/simple/
-      - pygmt==0.19.0.dev229
+      - pygmt==0.19.0.dev265


### PR DESCRIPTION
Previously, we have to use `\t` to indent the GMT commands by four spaces, because four spaces are combined into one space in GMT. 

After PR https://github.com/GenericMappingTools/pygmt/pull/4605, we can use four spaces directly, which makes the codes more readable.