### PR TITLE
Bump to PyGMT v0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ This repository contains the Jupyter notebooks and supporting data used to gener
 
 ## Environment setup
 
-These notebooks require GMT, PyGMT, and other dependencies to be installed in the same environment. The `environment.yml` file can be used to create a conda environment with all the required dependencies.
+These notebooks require GMT, PyGMT, and other dependencies to be installed in the same environment.
+The `environment.yml` file can be used to create a conda environment with all the required dependencies.
 
 Create and activate the environment:
 ```bash

--- a/README.md
+++ b/README.md
@@ -22,14 +22,9 @@ This repository contains the Jupyter notebooks and supporting data used to gener
 
 ## Environment setup
 
-These notebooks require a **development version of PyGMT**. The environment definition
-in `environment.yml` currently installs PyGMT from TestPyPI:
-
-- GMT: `6.6.0`
-- PyGMT: `0.19.0.dev268`
+These notebooks require GMT, PyGMT, and other dependencies to be installed in the same environment. The `environment.yml` file can be used to create a conda environment with all the required dependencies.
 
 Create and activate the environment:
-
 ```bash
 conda env create -f environment.yml
 conda activate pygmt-paper-figures
@@ -47,7 +42,6 @@ Then open the notebooks and run them within the `pygmt-paper-figures` environmen
 
 ## Notes
 
-- The notebooks expect GMT to be available through the same environment.
 - Some figures download remote resources or rely on online datasets.
 - Figure outputs are typically saved as PNG files from within the notebooks.
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,17 +3,15 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.14.5
+  - python=3.14.6
   - contextily=1.7.0
-  - geopandas=1.1.3
+  - geopandas=1.1.4
   - ghostscript=10.07.1
   - gmt=6.6.0
-  - jupyterlab=4.5.7
+  - jupyterlab=4.6.1
   - pandas=3.0.3
   - pip=26.1.2
+  - pygmt=0.19.0
   - requests=2.34.2
   - rioxarray=0.22.0
   - xarray=2026.4.0
-  - pip:
-      - --index-url https://test.pypi.org/simple/
-      - pygmt==0.19.0.dev268


### PR DESCRIPTION
Update environment.yml and README after PyGMT v0.19.0 is released.